### PR TITLE
Use the latest AMS version that we have sigpatches for instead of just latest.

### DIFF
--- a/include/download.h
+++ b/include/download.h
@@ -23,6 +23,7 @@
 #define HEKATE_URL	"https://api.github.com/repos/CTCaer/hekate/releases"
 #define PATCH_URL	"https://github.com/eXhumer/patches/releases/latest/download/sigpatches.zip"
 #define APP_URL		"https://github.com/eXhumer/atmosphere-updater/releases/latest/download/atmosphere-updater.nro"
+#define AMS_SUPPORTED_URL "https://raw.githubusercontent.com/ii0606226/atmoshere-supported/master/version"
 
 int downloadFile(const char *url, const char *output, int api_mode);
 

--- a/include/download.h
+++ b/include/download.h
@@ -20,6 +20,7 @@
 #define _DOWNLOAD_H_
 
 #define AMS_URL		"https://api.github.com/repos/Atmosphere-NX/Atmosphere/releases"
+#define AMS_URL_WITH_VERSION "https://api.github.com/repos/Atmosphere-NX/Atmosphere/releases/tags/%s"
 #define HEKATE_URL	"https://api.github.com/repos/CTCaer/hekate/releases"
 #define PATCH_URL	"https://github.com/eXhumer/patches/releases/latest/download/sigpatches.zip"
 #define APP_URL		"https://github.com/eXhumer/atmosphere-updater/releases/latest/download/atmosphere-updater.nro"

--- a/source/util.c
+++ b/source/util.c
@@ -129,7 +129,7 @@ void writeLatestAtmosphereVersion()
 			char c;
 			int i = 0;
 			while ((c = fgetc(fp)) != EOF)
-	{
+			{
 				if (c == '\n' || c == '\r')
 					break;
 				supportedVersionNumber[i] = c;
@@ -140,12 +140,12 @@ void writeLatestAtmosphereVersion()
 		}
 		snprintf(g_supportedAtmosphereVersion, sizeof(g_supportedAtmosphereVersion), supportedVersionNumber);
 		if (strcmp(g_amsVersionWithoutHash, supportedVersionNumber) != 0)
-			{
-				char buffer[50];
+		{
+			char buffer[50];
 			snprintf(buffer, sizeof(buffer), "- Latest supported: %s", supportedVersionNumber);
-				updateString = buffer;
-			}
+			updateString = buffer;
 		}
+	}
 	snprintf(g_latestAtmosphereVersion, sizeof(g_latestAtmosphereVersion), updateString);
 }
 


### PR DESCRIPTION
Primitive realization of remotely controlled atmosphere version selection.
The intention of changes is to prevent software from downloading the fresh releases of Atmosphere prior to sigpatches becoming available, and, consequently, prevent users from breaking their setup by running the updater.
The tag of the latest supported atmosphere version (i.e. "0.14.1", "0.14.2") should be available at some URL (i.e. link to "raw.githubusercontent.com" of some repo or some repo published with "pages.github.com").
Provided changes make the software work with the said tag instead of the latest Atmosphere release.
